### PR TITLE
Support FDG

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,8 +6,6 @@ name: Run tests
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,9 @@ name: Run tests
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "*" ]
+  pull_request:
+    branches: [ "*" ]
 
 jobs:
   build:

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,7 +18,8 @@ const config = {
     "json-summary",
     "text",
     "lcov"
-  ]
+  ],
+  testTimeout: 60000,
 };
 
 export default config;

--- a/src/anchorage/anchorage.service.ts
+++ b/src/anchorage/anchorage.service.ts
@@ -12,7 +12,7 @@ import {GraphQLService} from "../graphql.service";
 import {gql} from "@apollo/client/core";
 import { JsonRpcProvider } from '@ethersproject/providers'
 import {ethers} from "ethers";
-import {retainOldStructure} from "../utils";
+import {retainOldStructure, FDGABI } from "../utils";
 
 export class AnchorageGraphQLService extends GraphQLService {
     async findWithdrawalsProven(
@@ -417,6 +417,144 @@ export class AnchorageGraphQLService extends GraphQLService {
         }
 
         return withdrawalTransactions
+    }
+
+    async getFDGSubmissions(chainId: string | number, index: null | number = null, first: number = 1) {
+        try {
+            const whereClause = index !== null
+                ? `{ resolvedStatus: 2, index_lte: ${index} }`
+                : `{ resolvedStatus: 2 }`;
+            const qry = gql`
+                query GetDisputeGameCreateds {
+                    disputeGameCreateds(
+                        orderBy: index,
+                        orderDirection: desc,
+                        first: ${first},
+                        where: ${whereClause}
+                    ) {
+                        id
+                        index
+                        rootClaim
+                    }
+                }
+            `
+            const result = await this.conductQuery(
+                qry,
+                undefined,
+                chainId,
+                EGraphQLService.DisputeGameFactory
+            )
+            const submissions = []
+            const rpcEndpoint = this.getRpcEndpoint(Number(chainId))
+            const provider = new JsonRpcProvider(rpcEndpoint)
+            if (result?.data?.disputeGameCreateds?.length) {
+                for (const submission of result.data.disputeGameCreateds) {
+                    const FDGAddress = submission.id
+                    const FDGContract = new ethers.Contract(FDGAddress, FDGABI, provider)
+                    const l2BlockNumber = await FDGContract.l2BlockNumber()
+                    submissions.push({
+                        id: FDGAddress,
+                        index: Number(submission.index),
+                        l2BlockNumber: l2BlockNumber.toNumber(),
+                        rootClaim: submission.rootClaim,
+                    })
+                }
+                return submissions
+            }
+            console.log('graph-utils: getFDGSubmitted: No FDG found')
+            return [{ index: 0, l2BlockNumber: 0, rootClaim: '0x', id: ethers.constants.AddressZero }]
+        } catch (e) {
+            console.log('graph-utils: getFDGSubmitted: Error', e)
+            return [{ index: 0, l2BlockNumber: 0, rootClaim: '0x', id: ethers.constants.AddressZero }]
+        }
+    }
+
+    // Fraud proofing specific functions
+    // If the block number is not found, return 0
+    async getLatestFDGSubmittedBlock(
+        chainId: string | number
+    ) {
+        try {
+            const result = await this.getFDGSubmissions(chainId)
+            return result[0].l2BlockNumber
+        } catch (e) {
+            console.log('graph-utils: getLatestFDGSubmittedBlock: Error', e)
+            return 0
+        }
+    }
+
+    async getRootClaimOfFDGSubmission(
+        chainId: string | number,
+        blockNumber: number
+    ) {
+        try {
+            // get latest FDG submission
+            const latestFDGSubmission = await this.getFDGSubmissions(chainId)
+            const latestSubmittedIndex = latestFDGSubmission[0].index
+            const latestSubmittedBlockNumber = latestFDGSubmission[0].l2BlockNumber
+
+            // get first FDG submission
+            const firstFDGSubmission = await this.getFDGSubmissions(chainId, 0)
+            const firstSubmittedBlockNumber = firstFDGSubmission[0].l2BlockNumber
+
+            // Neeeds double check
+            // You need to resubmit the proof if the block number is less than the first submission
+            // Or you can claim the reward directly
+            if (blockNumber < firstSubmittedBlockNumber) {
+                return {
+                    status: 'failure',
+                    error: 'Less than first submission'
+                }
+            }
+            if (blockNumber > latestSubmittedBlockNumber) {
+                return {
+                    status: 'failure',
+                    error: 'Greater than latest submission',
+                }
+            }
+
+            const step = 10
+            let prevSubmittedIndex = latestSubmittedIndex
+            let prevSubmittedBlockNumber = latestSubmittedBlockNumber
+            let prevRootClaim = latestFDGSubmission[0].rootClaim
+            while (prevSubmittedBlockNumber > blockNumber) {
+                const prevFDGSubmissions = await this.getFDGSubmissions(chainId, prevSubmittedIndex, step)
+                for (const prevFDGSubmission of prevFDGSubmissions) {
+                    if (prevFDGSubmission.l2BlockNumber < blockNumber) {
+                        return {
+                            status: 'success',
+                            index: prevSubmittedIndex,
+                            rootClaim: prevRootClaim,
+                            l2BlockNumber: prevSubmittedBlockNumber,
+                        }
+                    }
+                    // special case
+                    if (prevFDGSubmission.l2BlockNumber === blockNumber) {
+                        return {
+                            status: 'success',
+                            index: prevFDGSubmission.index,
+                            rootClaim: prevFDGSubmission.rootClaim,
+                            l2BlockNumber: prevFDGSubmission.l2BlockNumber,
+                        }
+                    }
+                    prevSubmittedIndex = prevFDGSubmission.index
+                    prevSubmittedBlockNumber = prevFDGSubmission.l2BlockNumber
+                    prevRootClaim = prevFDGSubmission.rootClaim
+                }
+            }
+
+            console.log('graph-utils: getStateRootOfFDGSubmission: Cannot find the root claim')
+            return {
+                status: 'failure',
+                error: 'Unknown error - cannot find the root claim',
+            }
+        } catch (e) {
+            console.log('graph-utils: getStateRootOfFDGSubmission: Error', e)
+            return {
+                status: 'failure',
+                error: 'Unknown error',
+            }
+        }
     }
 }
 

--- a/src/anchorage/anchorage.service.ts
+++ b/src/anchorage/anchorage.service.ts
@@ -340,6 +340,7 @@ export class AnchorageGraphQLService extends GraphQLService {
                         token: event.l2Token,
                         originChainId: networkConfig.L2.chainId,
                         timeStamp: event.timestamp_initiated,
+                        timeStamp_proven: event.timestamp_
                     },
         }
     }

--- a/src/anchorage/types.ts
+++ b/src/anchorage/types.ts
@@ -27,6 +27,7 @@ export interface IHandleProveWithdrawalConfig {
     withdrawalHash?: string
     blockHash?: string
     timeStamp?: number
+    timeStamp_proven?: number
 }
 //#endregion
 

--- a/src/graphql.service.ts
+++ b/src/graphql.service.ts
@@ -125,7 +125,7 @@ export class GraphQLService {
                 local: '',
             },
             [EGraphQLService.DisputeGameFactory]: {
-                gql: this.withSubgraphId('3ypGLssvTVBZzegJaK4kFmr8exE9ugG35Duzc1p3S1E4')
+                gql: this.withSubgraphId('366aAux7wdCaJDZCqFRYQCAu9EcsvKn1KEMFMmAcVGb4')
             }
         },
         // Boba Sepolia
@@ -150,6 +150,20 @@ export class GraphQLService {
                 local: 'http://graph-node_bnb:8000/subgraphs/name/light-bridge',
             },
         },
+    }
+
+    RPC_ENDPOINTS = {
+        // Sepolia
+        11155111: {
+            url: 'https://ethereum-sepolia.publicnode.com/',
+        },
+    }
+
+    getRpcEndpoint(chainId: number) {
+        if (!this.RPC_ENDPOINTS[chainId]) {
+            throw new Error("No RPC endpoint for network: " + chainId)
+        }
+        return this.RPC_ENDPOINTS[chainId]
     }
 
     getBridgeEndpoint = (chainId, service: EGraphQLService, useLocal = false) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,3 +31,8 @@ export const retainOldStructure = (data: any[]) => {
         };
     });
 }
+
+export const FDGABI = [
+    {"type":"function","name":"l2BlockNumber","inputs":[],"outputs":[{"name":"l2BlockNumber_","type":"uint256","internalType":"uint256"}],"stateMutability":"pure"},
+    {"type":"function","name":"rootClaim","inputs":[],"outputs":[{"name":"rootClaim_","type":"bytes32","internalType":"Claim"}],"stateMutability":"pure"}
+]

--- a/tests/integration/dispute-game-factory.spec.ts
+++ b/tests/integration/dispute-game-factory.spec.ts
@@ -1,4 +1,6 @@
-import {EGraphQLService, graphQLService} from "../../src";
+import { ethers } from "ethers";
+import { EGraphQLService, graphQLService, anchorageGraphQLService } from "../../src";
+import { FDGABI } from "../../src/utils";
 
 describe('Anchorage: Integration Test', function () {
     const service = graphQLService;
@@ -7,4 +9,54 @@ describe('Anchorage: Integration Test', function () {
         const bridgeEndpoint = service.getBridgeEndpoint(chainId, EGraphQLService.DisputeGameFactory);
         expect(bridgeEndpoint).toEqual(graphQLService.GRAPHQL_ENDPOINTS[chainId][EGraphQLService.DisputeGameFactory].gql)
     });
+
+    it('Latest submitted Block reachable on: Sepolia', async () => {
+        const chainId = 11155111;
+        const res = await anchorageGraphQLService.getLatestFDGSubmittedBlock(chainId);
+        expect(res).toBeGreaterThan(0)
+    });
+
+    it('Submitted Block reachable on: Sepolia', async () => {
+        const chainId = 11155111;
+        const latestBlockNumber = await anchorageGraphQLService.getLatestFDGSubmittedBlock(chainId);
+        const latestSubmission = await anchorageGraphQLService.getFDGSubmissions(chainId);
+        expect(latestSubmission.length).toEqual(1);
+        expect(latestSubmission[0].l2BlockNumber).toEqual(latestBlockNumber)
+
+        const submissions = await anchorageGraphQLService.getFDGSubmissions(chainId, latestSubmission[0].index, 5);
+        expect(submissions.length).toEqual(5);
+        expect(submissions[0].l2BlockNumber).toEqual(latestBlockNumber);
+        expect(submissions[0].l2BlockNumber).toBeGreaterThan(submissions[1].l2BlockNumber);
+        expect(submissions[0].index).toEqual(submissions[1].index + 1);
+
+        const prevSubmissions = await anchorageGraphQLService.getFDGSubmissions(chainId, submissions[4].index, 5);
+        expect(prevSubmissions.length).toEqual(5);
+        expect(prevSubmissions[0].l2BlockNumber).toEqual(submissions[4].l2BlockNumber);
+        expect(prevSubmissions[0].index).toEqual(submissions[4].index);
+    });
+
+    it('Get root claim from submissions', async () => {
+        const chainId = 11155111;
+
+        const latestSubmissions = await anchorageGraphQLService.getFDGSubmissions(chainId, null, 20);
+        const FDGAddress = latestSubmissions[4].id;
+        const rpcEndpoint = anchorageGraphQLService.getRpcEndpoint(Number(chainId));
+        const provider = new ethers.providers.JsonRpcProvider(rpcEndpoint);
+        const FDGContract = new ethers.Contract(FDGAddress, FDGABI, provider);
+        const l2BlockNumber = (await FDGContract.l2BlockNumber()).toNumber();
+
+        const testingL2BlockNumber = l2BlockNumber - 10;
+
+        const submission = await anchorageGraphQLService.getRootClaimOfFDGSubmission(chainId, testingL2BlockNumber);
+        expect(submission.status).toEqual("success");
+        expect(submission.rootClaim).toEqual(latestSubmissions[4].rootClaim);
+        expect (submission.l2BlockNumber).toEqual(latestSubmissions[4].l2BlockNumber);
+        expect(submission.index).toEqual(latestSubmissions[4].index);
+
+        const submission2 = await anchorageGraphQLService.getRootClaimOfFDGSubmission(chainId, l2BlockNumber);
+        expect(submission2.status).toEqual("success");
+        expect(submission2.rootClaim).toEqual(latestSubmissions[4].rootClaim);
+        expect (submission2.l2BlockNumber).toEqual(latestSubmissions[4].l2BlockNumber);
+        expect(submission2.index).toEqual(latestSubmissions[4].index);
+    })
 });


### PR DESCRIPTION
Now we can fully rely on our subgraphs.

We have two functions:
- getLatestFDGSubmittedBlock(chainId) -> It returns the l2 block number of latest FDG game that has been resolved. Any l2 withdrawal transaction before this block number can submit the proof.
If something goes wrong, it return 0.
- getRootClaimOfFDGSubmission(chainId, blockNumber) -> It returns 
```
{ status: 'success', id: FDG_ADDRESS, rootClaim, l2BlockNumber, index }
```
given a l2 block number.

If the game has been created or resolved, it returns
```
{ status: 'error', error:' 'No submission found for the given block number' }
```
For any other problems, it returns
```
{ status: 'error', error:' 'Unknown error' }
```

> These issues have been fixed
> I am worried about the RPC endpoint. 
> I am talking with Tenderly to see if there is a way to use their RPC endpoint in our gateway.